### PR TITLE
Revert "build(deps): bump python from 3.12.7-slim to 3.13.0-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.13.0-slim
+FROM docker.io/python:3.12.7-slim
 
 ENV MPLCONFIGDIR /tmp
 RUN pip install --upgrade wheel pip


### PR DESCRIPTION
Reverts ngine-io/scalr#144